### PR TITLE
Bugfix/disable auto create fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ You can override the default solr schema name by setting `SOLR_COLLECTION`, but 
 
 ## Load data
 
-This module loads data from a condensed SDRF in an SCXA experiment to the sc-analytics collection in solr. These routines expect the collection to be created already, and work as an update to the content of the collection.
+This module loads data from a condensed SDRF in an SCXA experiment to the scxa-analytics-v? collection in Solr. These routines expect the collection to be created already, and work as an update to the content of the collection.
 
 ```
 export SOLR_HOST=192.168.99.100:32080

--- a/bin/create-scxa-analytics-schema.sh
+++ b/bin/create-scxa-analytics-schema.sh
@@ -274,6 +274,13 @@ curl -X POST -H 'Content-type:application/json' --data-binary '{
   "delete-updateprocessor": "scxa_analytics_v2_dedup"
 }' http://$HOST/solr/$CORE/config
 
+printf "\n\nDisable autoCreateFields (aka “Data driven schema”)"
+curl -X POST -H 'Content-type:application/json' --data-binary '{
+  "set-user-property": {
+    "update.autoCreateFields": "false"
+  }
+}'
+
 printf "\n\nCreate update processor "
 curl -X POST -H 'Content-type:application/json' --data-binary '{
   "add-updateprocessor":

--- a/bin/create-scxa-analytics-schema.sh
+++ b/bin/create-scxa-analytics-schema.sh
@@ -269,11 +269,8 @@ curl -X POST -H 'Content-type:application/json' --data-binary '{
 #############################################################################
 printf "\n\nDelete update processor"
 curl -X POST -H 'Content-type:application/json' --data-binary '{
-  "delete-updateprocessor":
-  {
-    "name": "scxa_analytics_v2_dedup"
-  }
-}' http://$HOST/solr/$CORE/schema
+  "delete-updateprocessor": "scxa_analytics_v2_dedup"
+}' http://$HOST/solr/$CORE/config
 
 printf "\n\nCreate update processor"
 curl -X POST -H 'Content-type:application/json' --data-binary '{

--- a/bin/create-scxa-analytics-schema.sh
+++ b/bin/create-scxa-analytics-schema.sh
@@ -279,7 +279,7 @@ curl -X POST -H 'Content-type:application/json' --data-binary '{
   "set-user-property": {
     "update.autoCreateFields": "false"
   }
-}'
+}' http://$HOST/solr/$CORE/config
 
 printf "\n\nCreate update processor "
 curl -X POST -H 'Content-type:application/json' --data-binary '{

--- a/bin/create-scxa-analytics-schema.sh
+++ b/bin/create-scxa-analytics-schema.sh
@@ -7,7 +7,7 @@ CORE=${SOLR_COLLECTION:-"scxa-analytics-v$SCHEMA_VERSION"}
 
 #############################################################################################
 
-printf "\n\nDelete field experiment_accession"
+printf "\n\nDelete field experiment_accession "
 curl -X POST -H 'Content-type:application/json' --data-binary '{
   "delete-field":
   {
@@ -15,7 +15,7 @@ curl -X POST -H 'Content-type:application/json' --data-binary '{
   }
 }' http://$HOST/solr/$CORE/schema
 
-printf "\n\nCreate field experiment_accession (string)"
+printf "\n\nCreate field experiment_accession (string) "
 curl -X POST -H 'Content-type:application/json' --data-binary '{
   "add-field":
   {
@@ -28,8 +28,8 @@ curl -X POST -H 'Content-type:application/json' --data-binary '{
 
 
 #############################################################################################
-# TODO hacer congruente con cell_id
-printf "\n\nDelete field cell_id"
+
+printf "\n\nDelete field cell_id "
 curl -X POST -H 'Content-type:application/json' --data-binary '{
   "delete-field" :
   {
@@ -37,7 +37,7 @@ curl -X POST -H 'Content-type:application/json' --data-binary '{
   }
 }' http://$HOST/solr/$CORE/schema
 
-printf "\n\nCreate field cell_id (string)"
+printf "\n\nCreate field cell_id (string) "
 curl -X POST -H 'Content-type:application/json' --data-binary '{
   "add-field":
   {
@@ -49,7 +49,7 @@ curl -X POST -H 'Content-type:application/json' --data-binary '{
 
 #############################################################################################
 
-printf "\n\nDelete field factors"
+printf "\n\nDelete field factors "
 curl -X POST -H 'Content-type:application/json' --data-binary '{
   "delete-field":
   {
@@ -57,7 +57,7 @@ curl -X POST -H 'Content-type:application/json' --data-binary '{
   }
 }' http://$HOST/solr/$CORE/schema
 
-printf "\n\nCreate field factors (string, multiValued)"
+printf "\n\nCreate field factors (string, multiValued) "
 curl -X POST -H 'Content-type:application/json' --data-binary '{
   "add-field":
   {
@@ -70,7 +70,7 @@ curl -X POST -H 'Content-type:application/json' --data-binary '{
 
 #############################################################################################
 
-printf "\n\nDelete field characteristics"
+printf "\n\nDelete field characteristics "
 curl -X POST -H 'Content-type:application/json' --data-binary '{
   "delete-field":
   {
@@ -78,7 +78,7 @@ curl -X POST -H 'Content-type:application/json' --data-binary '{
   }
 }' http://$HOST/solr/$CORE/schema
 
-printf "\n\nCreate field characteristics (string, multiValued)"
+printf "\n\nCreate field characteristics (string, multiValued) "
 curl -X POST -H 'Content-type:application/json' --data-binary '{
   "add-field":
   {
@@ -92,16 +92,16 @@ curl -X POST -H 'Content-type:application/json' --data-binary '{
 #############################################################################################
 # Deletion of copy field needs to come before the deletion of the actual fields.
 # 1.1
-printf "\n\nDelete copy field for facet_factor_*"
+printf "\n\nDelete copy field rule for facet_factor_* "
 curl -X POST -H 'Content-type:application/json' --data-binary '{
   "delete-copy-field":{
-     "source":"factor_*",
+     "source": "factor_*",
      "dest": "facet_factor_*" }
 }' http://$HOST/solr/$CORE/schema
 
 #############################################################################################
 # 1.2
-printf "\n\nDelete dynamic field factor_*"
+printf "\n\nDelete dynamic field rule factor_* "
 curl -X POST -H 'Content-type:application/json' --data-binary '{
   "delete-dynamic-field":
   {
@@ -109,7 +109,7 @@ curl -X POST -H 'Content-type:application/json' --data-binary '{
   }
 }' http://$HOST/solr/$CORE/schema
 # 1.3
-printf "\n\nCreate dynamic rule factor_* (lowercase, multiValued)"
+printf "\n\nCreate dynamic field rule factor_* (lowercase, multiValued) "
 curl -X POST -H 'Content-type:application/json' --data-binary '{
   "add-dynamic-field":
   {
@@ -121,7 +121,7 @@ curl -X POST -H 'Content-type:application/json' --data-binary '{
 
 #############################################################################################
 # 1.4
-printf "\n\nDelete dynamic field facet_factor_*"
+printf "\n\nDelete dynamic field rule facet_factor_* "
 curl -X POST -H 'Content-type:application/json' --data-binary '{
   "delete-dynamic-field":
   {
@@ -129,7 +129,7 @@ curl -X POST -H 'Content-type:application/json' --data-binary '{
   }
 }' http://$HOST/solr/$CORE/schema
 # 1.5
-printf "\n\nCreate dynamic rule facet_factor_* (lowercase, multiValued)"
+printf "\n\nCreate dynamic field rule facet_factor_* (lowercase, multiValued) "
 curl -X POST -H 'Content-type:application/json' --data-binary '{
   "add-dynamic-field":
   {
@@ -142,10 +142,10 @@ curl -X POST -H 'Content-type:application/json' --data-binary '{
 
 #############################################################################################
 # 1.6
-printf "\n\nCreate copy field for facet_factor_* (lowercase, multiValued)"
+printf "\n\nCreate copy field rule factor_* -> facet_factor_* "
 curl -X POST -H 'Content-type:application/json' --data-binary '{
   "add-copy-field":{
-     "source":"factor_*",
+     "source": "factor_*",
      "dest": "facet_factor_*" }
 }' http://$HOST/solr/$CORE/schema
 
@@ -154,24 +154,26 @@ curl -X POST -H 'Content-type:application/json' --data-binary '{
 #############################################################################################
 # Deletion of copy field needs to come before the deletion of the actual fields.
 # 2.1
-printf "\n\nDelete copy field for facet_characteristic_*"
+printf "\n\nDelete copy field rule characteristic_* -> facet_characteristic_* "
 curl -X POST -H 'Content-type:application/json' --data-binary '{
   "delete-copy-field":{
-     "source":"characteristic_*",
+     "source": "characteristic_*",
      "dest": "facet_characteristic_*" }
 }' http://$HOST/solr/$CORE/schema
 
 #############################################################################################
 # 2.2
-printf "\n\nDelete dynamic field characteristic_*"
+printf "\n\nDelete dynamic field rule characteristic_* "
 curl -X POST -H 'Content-type:application/json' --data-binary '{
   "delete-dynamic-field":
   {
     "name": "characteristic_*"
   }
 }' http://$HOST/solr/$CORE/schema
+
+#############################################################################################
 # 2.3
-printf "\n\nCreate dynamic rule characteristic_* (lowercase, multiValued)"
+printf "\n\nCreate dynamic field rule characteristic_* (lowercase, multiValued) "
 curl -X POST -H 'Content-type:application/json' --data-binary '{
   "add-dynamic-field":
   {
@@ -183,15 +185,17 @@ curl -X POST -H 'Content-type:application/json' --data-binary '{
 
 #############################################################################################
 # 2.4
-printf "\n\nDelete dynamic field facet_characteristic_*"
+printf "\n\nDelete dynamic field rule facet_characteristic_* "
 curl -X POST -H 'Content-type:application/json' --data-binary '{
   "delete-dynamic-field":
   {
     "name": "facet_characteristic_*"
   }
 }' http://$HOST/solr/$CORE/schema
+
+#############################################################################################
 # 2.5
-printf "\n\nCreate dynamic rule facet_characteristic_* (lowercase, multiValued)"
+printf "\n\nCreate dynamic field rule facet_characteristic_* (lowercase, multiValued) "
 curl -X POST -H 'Content-type:application/json' --data-binary '{
   "add-dynamic-field":
   {
@@ -204,18 +208,16 @@ curl -X POST -H 'Content-type:application/json' --data-binary '{
 
 #############################################################################################
 # 2.6
-printf "\n\nCreate copy field for facet_characteristic_* (lowercase, multiValued)"
+printf "\n\nCreate copy field rule characteristic_* -> facet_characteristic_* "
 curl -X POST -H 'Content-type:application/json' --data-binary '{
   "add-copy-field":{
-     "source":"characteristic_*",
+     "source": "characteristic_*",
      "dest": "facet_characteristic_*" }
 }' http://$HOST/solr/$CORE/schema
 
 #############################################################################################
 
-
-
-printf "\n\nDelete field conditions_search"
+printf "\n\nDelete field conditions_search "
 curl -X POST -H 'Content-type:application/json' --data-binary '{
   "delete-field" :
   {
@@ -223,7 +225,7 @@ curl -X POST -H 'Content-type:application/json' --data-binary '{
   }
 }' http://$HOST/solr/$CORE/schema
 
-printf "\n\nDelete field type text_en_tight"
+printf "\n\nDelete field type text_en_tight "
 curl -X POST -H 'Content-type:application/json' --data-binary '{
   "delete-field-type":
   {
@@ -231,7 +233,7 @@ curl -X POST -H 'Content-type:application/json' --data-binary '{
   }
 }' http://$HOST/solr/$CORE/schema
 
-printf "\n\nCreate field type text_en_tight"
+printf "\n\nCreate field type text_en_tight "
 curl -X POST -H 'Content-type:application/json' --data-binary '{
   "add-field-type": {
     "name": "text_en_tight",
@@ -256,7 +258,7 @@ curl -X POST -H 'Content-type:application/json' --data-binary '{
   }
 }' http://$HOST/solr/$CORE/schema
 
-printf "\n\nCreate field conditions_search (text_en_tight)"
+printf "\n\nCreate field conditions_search (text_en_tight) "
 curl -X POST -H 'Content-type:application/json' --data-binary '{
   "add-field":
   {
@@ -267,12 +269,12 @@ curl -X POST -H 'Content-type:application/json' --data-binary '{
 
 
 #############################################################################
-printf "\n\nDelete update processor"
+printf "\n\nDelete update processor "
 curl -X POST -H 'Content-type:application/json' --data-binary '{
   "delete-updateprocessor": "scxa_analytics_v2_dedup"
 }' http://$HOST/solr/$CORE/config
 
-printf "\n\nCreate update processor"
+printf "\n\nCreate update processor "
 curl -X POST -H 'Content-type:application/json' --data-binary '{
   "add-updateprocessor":
   {

--- a/bin/create-scxa-gene2experiment-schema.sh
+++ b/bin/create-scxa-gene2experiment-schema.sh
@@ -49,7 +49,7 @@ curl -X POST -H 'Content-type:application/json' --data-binary '{
 printf "\n\nDelete update processor "
 curl -X POST -H 'Content-type:application/json' --data-binary '{
   "delete-updateprocessor": "'$CORE'_dedup"
-}' http://$HOST/solr/$CORE/schema
+}' http://$HOST/solr/$CORE/config
 
 printf "\n\nCreate update processor "
 curl -X POST -H 'Content-type:application/json' --data-binary '{

--- a/bin/create-scxa-gene2experiment-schema.sh
+++ b/bin/create-scxa-gene2experiment-schema.sh
@@ -7,7 +7,7 @@ CORE=${SOLR_COLLECTION:-"scxa-gene2experiment-v$SCHEMA_VERSION"}
 
 #############################################################################################
 
-printf "\n\nDelete field experiment_accession"
+printf "\n\nDelete field experiment_accession "
 curl -X POST -H 'Content-type:application/json' --data-binary '{
   "delete-field":
   {
@@ -15,7 +15,7 @@ curl -X POST -H 'Content-type:application/json' --data-binary '{
   }
 }' http://$HOST/solr/$CORE/schema
 
-printf "\n\nCreate field experiment_accession (string)"
+printf "\n\nCreate field experiment_accession (string) "
 curl -X POST -H 'Content-type:application/json' --data-binary '{
   "add-field":
   {
@@ -26,7 +26,7 @@ curl -X POST -H 'Content-type:application/json' --data-binary '{
 }' http://$HOST/solr/$CORE/schema
 
 #############################################################################################
-printf "\n\nDelete field bioentity_identifier"
+printf "\n\nDelete field bioentity_identifier "
 curl -X POST -H 'Content-type:application/json' --data-binary '{
   "delete-field" :
   {
@@ -34,7 +34,7 @@ curl -X POST -H 'Content-type:application/json' --data-binary '{
   }
 }' http://$HOST/solr/$CORE/schema
 
-printf "\n\nCreate field bioentity_identifier (string)"
+printf "\n\nCreate field bioentity_identifier (string) "
 curl -X POST -H 'Content-type:application/json' --data-binary '{
   "add-field":
   {
@@ -46,15 +46,12 @@ curl -X POST -H 'Content-type:application/json' --data-binary '{
 
 #############################################################################################
 
-printf "\n\nDelete update processor"
+printf "\n\nDelete update processor "
 curl -X POST -H 'Content-type:application/json' --data-binary '{
-  "delete-updateprocessor":
-  {
-    "name": "'$CORE'_dedup"
-  }
+  "delete-updateprocessor": "'$CORE'_dedup"
 }' http://$HOST/solr/$CORE/schema
 
-printf "\n\nCreate update processor"
+printf "\n\nCreate update processor "
 curl -X POST -H 'Content-type:application/json' --data-binary '{
   "add-updateprocessor":
   {

--- a/bin/create-scxa-gene2experiment-schema.sh
+++ b/bin/create-scxa-gene2experiment-schema.sh
@@ -51,6 +51,13 @@ curl -X POST -H 'Content-type:application/json' --data-binary '{
   "delete-updateprocessor": "'$CORE'_dedup"
 }' http://$HOST/solr/$CORE/config
 
+printf "\n\nDisable autoCreateFields (aka “Data driven schema”)"
+curl -X POST -H 'Content-type:application/json' --data-binary '{
+  "set-user-property": {
+    "update.autoCreateFields": "false"
+  }
+}' http://$HOST/solr/$CORE/config
+
 printf "\n\nCreate update processor "
 curl -X POST -H 'Content-type:application/json' --data-binary '{
   "add-updateprocessor":


### PR DESCRIPTION
Necessary if we want to use `id` as our signature field in the custom dedupe processor. Otherwise, because it’s missing in the JSON payload, Solr will auto-generate it with a UUID and the post-processor will also do the same, and we get the following error and loading fails:
```
{
  "responseHeader":{
    "status":400,
    "QTime":41},
  "error":{
    "metadata":[
      "error-class","org.apache.solr.common.SolrException",
      "root-error-class","org.apache.solr.common.SolrException"],
    "msg":"Document contains multiple values for uniqueKey field: id=[506cd71b-21fc-492b-be2c-272bca64fae3, 013390796c722093]",
    "code":400}}
```
