### PR TITLE
Delete analytics content

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,17 @@ export CONDENSED_SDRF_TSV=../scxa-test-experiments/magetab/E-GEOD-106540/E-GEOD-
 load_scxa_analytics_index.sh
 ```
 
+## Delete an experiment
+
+In order to delete a particular experiment's analytics solr documents based on its accession from a live index, do:
+
+```
+export EXP_ID=desired-exp-identifier
+export SOLR_HOST=192.168.99.100:32080
+
+delete_scxa_analytics_index.sh
+```
+
 ## Tests
 
 Tests are located in the `tests` directory and use bats. To run them, execute `bash tests/run-tests.sh`. The `tests` folder includes example data in tsv (a condensed SDRF) and in JSON (as it should be produced by the first step that translates the cond. SDRF to JSON).
@@ -64,6 +75,18 @@ export MATRIX_MARKT_ROWS_GENES_FILE=../path/to/E-GEOD-106540.aggregated_counts.m
 
 load_scxa_gene2experiment_index.sh
 ```
+
+## Delete an experiment
+
+In order to delete a particular experiment's gene2experiment solr documents based on its accession from a live index, do:
+
+```
+export EXP_ID=desired-exp-identifier
+export SOLR_HOST=192.168.99.100:32080
+
+delete-scxa-gene2experiment-exp-entries.sh
+```
+
 
 ## Tests
 

--- a/bin/delete_scxa_analytics_index.sh
+++ b/bin/delete_scxa_analytics_index.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+export SCHEMA_VERSION=2
+export SOLR_COLLECTION=scxa-analytics-v$SCHEMA_VERSION
+HOST=${SOLR_HOST:-localhost:8983}
+
+set -e
+
+[ -z ${EXP_ID+x} ] && echo "EXP_ID env var is needed." && exit 1
+
+curl "http://$HOST/solr/$SOLR_COLLECTION/update?commit=true" -H "Content-Type: text/xml" \
+  --data-binary "<delete><query>experiment_accession:$EXP_ID</query></delete>"

--- a/tests/analytics-check-experiment-available.sh
+++ b/tests/analytics-check-experiment-available.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+SCHEMA_VERSION=2
+
+set -e
+
+# on developers environment export SOLR_HOST_PORT and export SOLR_COLLECTION before running
+HOST=${SOLR_HOST:-"localhost:8983"}
+CORE=${SOLR_COLLECTION:-"scxa-analytics-v$SCHEMA_VERSION"}
+
+entries=$(curl "http://$HOST/solr/$CORE/select?fl=experiment_accession&q=experiment_accession:%22$EXP_ID%22" |   jq '.response.numFound')
+
+if [ $entries -lt 1 ]; then
+  echo "$EXP_ID not present in index $CORE at $HOST"
+  exit 1
+fi  

--- a/tests/analytics.bats
+++ b/tests/analytics.bats
@@ -94,3 +94,36 @@
   echo "output = ${output}"
   [ "$status" -eq 0 ]
 }
+
+@test "[analytics] Load additional dataset for deletion testing" {
+  if [ -z ${SOLR_HOST+x} ]; then
+    skip "SOLR_HOST not defined, skipping load to SOLR"
+  fi
+  export EXP_ID=E-GEOD-DELETE
+  export CONDENSED_SDRF_TSV=$BATS_TEST_DIRNAME/example-conds-sdrf-delete.tsv
+  sed s/E-GEOD-106540/$EXP_ID/ $BATS_TEST_DIRNAME/example-conds-sdrf.tsv > $CONDENSED_SDRF_TSV
+  run load_scxa_analytics_index.sh && rm $CONDENSED_SDRF_TSV && analytics-check-experiment-available.sh
+  echo "output = ${output}"
+  [ "$status" -eq 0 ]
+}
+
+@test '[analytics] Delete additional dataset' {
+  if [ -z ${SOLR_HOST+x} ]; then
+    skip "SOLR_HOST not defined, skipping load to SOLR"
+  fi
+  export EXP_ID=E-GEOD-DELETE
+  run delete_scxa_analytics_index.sh
+  echo "output = ${output}"
+  [ "$status" -eq 0 ]
+}
+
+@test '[analytics] Check that deleted experiment is no longer available, but previous one is' {
+  export EXP_ID=E-GEOD-DELETE
+  run analytics-check-experiment-available.sh
+  # this will return exit code 1 if the experiment is not available
+  [ "$status" -eq 1 ]
+  export EXP_ID=E-GEOD-106540
+  run analytics-check-experiment-available.sh
+  echo "output = ${output}"
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
This PR adds logic, testing and documentation for the deletion of an experiment's documents within the analytics index.