### PR TITLE
Use collection name in the dedupe processor

### DIFF
--- a/bin/create-scxa-analytics-schema.sh
+++ b/bin/create-scxa-analytics-schema.sh
@@ -287,7 +287,7 @@ printf "\n\nCreate update processor "
 curl -X POST -H 'Content-type:application/json' --data-binary '{
   "add-updateprocessor":
   {
-    "name": "scxa_analytics_v2_dedup"
+    "name": "'$CORE'_dedup"
     "class": "solr.processor.SignatureUpdateProcessorFactory",
     "enabled": "true",
     "signatureField": "id",

--- a/bin/load_scxa_analytics_index.sh
+++ b/bin/load_scxa_analytics_index.sh
@@ -5,7 +5,7 @@ set -e
 
 export SCHEMA_VERSION=2
 export SOLR_COLLECTION=scxa-analytics-v$SCHEMA_VERSION
-export PROCESSOR=scxa_analytics_v$SCHEMA_VERSION\_dedup
+export PROCESSOR=$SOLR_COLLECTION\_dedup
 
 echo "Loading cond. sdrf $CONDENSED_SDRF_TSV into host $SOLR_HOST collection $SOLR_COLLECTION..."
 


### PR DESCRIPTION
Effectively kebab-cases the dedupe processor, instead of the hard-coded snake-cased name.