### PR TITLE
Raise Solr’s memory to accomodate EFO v3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ env:
 
 before_install:
   - docker network create mynet
-  - docker run --net mynet --name my_solr -v $(pwd)/lib/solr-ontology-update-processor-1.1.jar:/opt/solr/server/solr/lib/solr-ontology-update-processor-1.1.jar -d -p 8983:8983 -t solr:7.1-alpine -DzkRun -Denable.runtime.lib=true
+  - docker run --net mynet --name my_solr -v $(pwd)/lib/solr-ontology-update-processor-1.1.jar:/opt/solr/server/solr/lib/solr-ontology-update-processor-1.1.jar -d -p 8983:8983 -t solr:7.1-alpine -DzkRun -Denable.runtime.lib=true -m 2g
 
 install:
   - docker build -t test/index-scxa-module .


### PR DESCRIPTION
EFO v2 was 57 MB, EFO v3 is now 181 MB. Solr default memory is 512 MB, making things quite tight.