### PR TITLE
Update scxa-analytics to use BioSolr 1.2 and commit explicitly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.8
 
 RUN apk update && apk add bash curl jq bats
 
-ENV BIOSOLR_JAR_PATH /usr/local/lib/solr-ontology-update-processor-1.1.jar
+ENV BIOSOLR_JAR_PATH /usr/local/lib/solr-ontology-update-processor-1.2.jar
 
 COPY bin/* /usr/local/bin/
 COPY lib/* /usr/local/lib/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Docker Repository on Quay](https://quay.io/repository/ebigxa/index-scxa-module/status "Docker Repository on Quay")](https://quay.io/repository/ebigxa/index-scxa-module)
 
-# Module for Single Cell Expression Atlas Solr index (v0.4.0)
+# Module for Single Cell Expression Atlas Solr index (v0.5.0)
 
 Scripts to create and load data into the `scxa-*` Solr indexes (for analytics and gene2experiment). Execution of tasks here require that `bin/` directory in the root of this repo is part of the path, and that the following executables are available:
 
@@ -10,7 +10,7 @@ Scripts to create and load data into the `scxa-*` Solr indexes (for analytics an
 
 Version 0.2.0 was used for loading the August/September 2018 Single Cell Expression Atlas release.
 
-# `scxa-analytics` index v4
+# `scxa-analytics` index v5
 
 ## Create collection
 To create the schema, set the environment variable `SOLR_HOST` to the appropriate server, and execute as shown
@@ -23,7 +23,7 @@ create-scxa-analytics-collection.sh
 ```
 
 ## Enable BioSolr
-`scxa-analytics-v4` makes use of the [BioSolr plugin](https://github.com/ebi-gene-expression-group/BioSolr) to perform ontology expansion on document indexing. In order to enable BioSolr, there are 2 options:
+`scxa-analytics-v5` makes use of the [BioSolr plugin](https://github.com/ebi-gene-expression-group/BioSolr) to perform ontology expansion on document indexing. In order to enable BioSolr, there are 2 options:
 
 ### Option 1: Local `.jar` file
 Place BioSolr jar (which can be found in the repository's `lib` directory) under `/server/solr/lib/` in your Solr installation directory.

--- a/bin/create-scxa-analytics-biosolr-lib.sh
+++ b/bin/create-scxa-analytics-biosolr-lib.sh
@@ -7,7 +7,7 @@ CWD=`dirname "$0"`
 # on developers environment export SOLR_HOST and export SOLR_COLLECTION before running
 HOST=${SOLR_HOST:-"localhost:8983"}
 CORE=${SOLR_COLLECTION:-"scxa-analytics-v$SCHEMA_VERSION"}
-BIOSOLR_JAR_PATH="${BIOSOLR_JAR_PATH:-${CWD}/../lib/solr-ontology-update-processor-1.1.jar}"
+BIOSOLR_JAR_PATH="${BIOSOLR_JAR_PATH:-${CWD}/../lib/solr-ontology-update-processor-1.2.jar}"
 
 #creates a new file descriptor 3 that redirects to 1 (STDOUT)
 exec 3>&1

--- a/bin/create-scxa-analytics-biosolr-lib.sh
+++ b/bin/create-scxa-analytics-biosolr-lib.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-SCHEMA_VERSION=4
+SCHEMA_VERSION=5
 
 set -e
 

--- a/bin/create-scxa-analytics-collection.sh
+++ b/bin/create-scxa-analytics-collection.sh
@@ -5,19 +5,19 @@ set -e
 
 # on developers environment export SOLR_HOST_PORT and export SOLR_COLLECTION before running
 HOST=${SOLR_HOST:-"localhost:8983"}
-CORE=${SOLR_COLLECTION:-"scxa-analytics-v$SCHEMA_VERSION"}
+COLLECTION=${SOLR_COLLECTION:-"scxa-analytics-v$SCHEMA_VERSION"}
 NUM_SHARDS=${SOLR_NUM_SHARDS:-1}
 REPLICATES=${SOLR_REPLICATES:-1}
 MAX_SHARDS_PER_NODE=${SOLR_MAX_SHARDS_PER_NODE:-1}
 
-printf "\n\nCreating collection $CORE based on $HOST"
-curl "http://$HOST/solr/admin/collections?action=CREATE&name=$CORE&numShards=$NUM_SHARDS&replicationFactor=$REPLICATES&maxShardsPerNode=$MAX_SHARDS_PER_NODE"
+printf "\n\nCreating collection $COLLECTION based on $HOST"
+curl "http://$HOST/solr/admin/collections?action=CREATE&name=$COLLECTION&numShards=$NUM_SHARDS&replicationFactor=$REPLICATES&maxShardsPerNode=$MAX_SHARDS_PER_NODE"
 
 # Set this value to whatever is needed, it doesn’t really matter with current Lucene versions
 # https://issues.apache.org/jira/browse/SOLR-4586
 MAX_BOOLEAN_CLAUSES=100000000
 printf "\n\nRaising value of maxBooleanClauses to $MAX_BOOLEAN_CLAUSES."
-curl "http://$HOST/solr/$CORE/config" -H 'Content-type:application/json' -d "
+curl "http://$HOST/solr/$COLLECTION/config" -H 'Content-type:application/json' -d "
 {
   "set-property": {
     "query.maxBooleanClauses" : ${MAX_BOOLEAN_CLAUSES}

--- a/bin/create-scxa-analytics-collection.sh
+++ b/bin/create-scxa-analytics-collection.sh
@@ -23,3 +23,27 @@ curl "http://$HOST/solr/$COLLECTION/config" -H 'Content-type:application/json' -
     "query.maxBooleanClauses" : ${MAX_BOOLEAN_CLAUSES}
   }
 }"
+
+# Disable hard and soft auto-commits, we’ll do that explicitly when convenient
+curl "http://$HOST/solr/$COLLECTION/config" -H 'Content-type:application/json' -d '{
+  "set-property": {
+    "updateHandler.autoCommit.maxTime":-1
+  }
+}'
+
+curl "http://$HOST/solr/$COLLECTION/config" -H 'Content-type:application/json' -d '{
+  "set-property": {
+    "updateHandler.autoCommit.maxDocs":-1
+  }
+}'
+
+curl "http://$HOST/solr/$COLLECTION/config" -H 'Content-type:application/json' -d '{
+  "set-property": {
+    "updateHandler.autoSoftCommit.maxTime":-1
+  }
+}'
+
+curl "http://$HOST/solr/$COLLECTION/config" -H 'Content-type:application/json' -d '{
+  "set-property": {
+    "updateHandler.autoSoftCommit.maxDocs":-1
+}'

--- a/bin/create-scxa-analytics-collection.sh
+++ b/bin/create-scxa-analytics-collection.sh
@@ -46,4 +46,5 @@ curl "http://$HOST/solr/$COLLECTION/config" -H 'Content-type:application/json' -
 curl "http://$HOST/solr/$COLLECTION/config" -H 'Content-type:application/json' -d '{
   "set-property": {
     "updateHandler.autoSoftCommit.maxDocs":-1
+  }
 }'

--- a/bin/create-scxa-analytics-collection.sh
+++ b/bin/create-scxa-analytics-collection.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-SCHEMA_VERSION=4
+SCHEMA_VERSION=5
 
 set -e
 

--- a/bin/create-scxa-analytics-config-set.sh
+++ b/bin/create-scxa-analytics-config-set.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-SCHEMA_VERSION=4
+SCHEMA_VERSION=5
 
 set -e
 

--- a/bin/create-scxa-analytics-schema.sh
+++ b/bin/create-scxa-analytics-schema.sh
@@ -360,6 +360,8 @@ curl -X POST -H 'Content-type:application/json' --data-binary '{
     "definitionField": "",
     "childField": "",
     "descendantsField": "",
-    "ontologyURI": "https://raw.githubusercontent.com/EBISPOT/scatlas_ontology/zooma_file_proc_release/scatlas.owl"
+    "ontologyURI": "https://raw.githubusercontent.com/EBISPOT/scatlas_ontology/zooma_file_proc_release/scatlas.owl",
+    "includeChildren": false,
+    "includeDescendants": false
   }
 }' http://$HOST/solr/$CORE/config

--- a/bin/create-scxa-analytics-schema.sh
+++ b/bin/create-scxa-analytics-schema.sh
@@ -67,48 +67,6 @@ curl -X POST -H 'Content-type:application/json' --data-binary '{
 }' http://$HOST/solr/$CORE/schema
 
 #############################################################################################
-
-printf "\n\nDelete field ontology_synonyms "
-curl -X POST -H 'Content-type:application/json' --data-binary '{
-  "delete-field":
-  {
-    "name": "ontology_synonyms"
-  }
-}' http://$HOST/solr/$CORE/schema
-
-printf "\n\nCreate ontology_synonyms (string, multiValued, docValues) "
-curl -X POST -H 'Content-type:application/json' --data-binary '{
-  "add-field":
-  {
-    "name": "ontology_synonyms",
-    "type": "string",
-    "multiValued": true,
-    "docValues": true
-  }
-}' http://$HOST/solr/$CORE/schema
-
-#############################################################################################
-
-printf "\n\nDelete field ontology_definition "
-curl -X POST -H 'Content-type:application/json' --data-binary '{
-  "delete-field":
-  {
-    "name": "ontology_definition"
-  }
-}' http://$HOST/solr/$CORE/schema
-
-printf "\n\nCreate ontology_synonyms (string, multiValued) "
-curl -X POST -H 'Content-type:application/json' --data-binary '{
-  "add-field":
-  {
-    "name": "ontology_definition",
-    "type": "string",
-    "multiValued": true,
-    "docValues": true
-  }
-}' http://$HOST/solr/$CORE/schema
-
-#############################################################################################
 # Deletion of copy field needs to come before the deletion of the actual fields.
 # 1.1
 printf "\n\nDelete copy field rule for facet_factor_* "
@@ -354,12 +312,7 @@ curl -X POST -H 'Content-type:application/json' --data-binary '{
     "name": "'$CORE'_ontology_expansion"
     "runtimeLib": true,
     "class": "uk.co.flax.biosolr.solr.update.processor.OntologyUpdateProcessorFactory",
-    "enabled": "true",
     "annotationField": "ontology_annotation",
-    "synonymsField": "ontology_synonyms",
-    "definitionField": "",
-    "childField": "",
-    "descendantsField": "",
     "ontologyURI": "https://raw.githubusercontent.com/EBISPOT/scatlas_ontology/zooma_file_proc_release/scatlas.owl",
     "includeChildren": false,
     "includeDescendants": false

--- a/bin/create-scxa-analytics-schema.sh
+++ b/bin/create-scxa-analytics-schema.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-SCHEMA_VERSION=4
+SCHEMA_VERSION=5
 
 # on developers environment export SOLR_HOST_PORT and export SOLR_COLLECTION before running
 HOST=${SOLR_HOST:-"localhost:8983"}

--- a/bin/delete-scxa-analytics-config-set.sh
+++ b/bin/delete-scxa-analytics-config-set.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-export SCHEMA_VERSION=4
+export SCHEMA_VERSION=5
 export SOLR_COLLECTION=scxa-analytics-v$SCHEMA_VERSION
 HOST=${SOLR_HOST:-localhost:8983}
 CONFIG=$SOLR_COLLECTION

--- a/bin/delete_scxa_analytics_index.sh
+++ b/bin/delete_scxa_analytics_index.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-export SCHEMA_VERSION=4
+export SCHEMA_VERSION=5
 export SOLR_COLLECTION=scxa-analytics-v$SCHEMA_VERSION
 HOST=${SOLR_HOST:-localhost:8983}
 

--- a/bin/loadJSONIndexToSolr.sh
+++ b/bin/loadJSONIndexToSolr.sh
@@ -7,18 +7,18 @@ echo $HOST
 echo $COLLECTION
 
 if [ $PROCESSOR ] && [ $ONTOLOGY_PROCESSOR ]; then
-	PROCESSOR="&processor="$PROCESSOR","$ONTOLOGY_PROCESSOR
+	PROCESSOR="?processor="$PROCESSOR","$ONTOLOGY_PROCESSOR
 elif [ $PROCESSOR ]; then 
-	PROCESSOR="&processor="$PROCESSOR
+	PROCESSOR="?processor="$PROCESSOR
 elif [ $ONTOLOGY_PROCESSOR ]; then
-	PROCESSOR="&processor="$ONTOLOGY_PROCESSOR
+	PROCESSOR="?processor="$ONTOLOGY_PROCESSOR
 fi
 
 #creates a new file descriptor 3 that redirects to 1 (STDOUT)
 exec 3>&1
 # Run curl in a separate command, capturing output of -w "%{http_code}" into HTTP_STATUS
 # and sending the content to this command's STDOUT with -o >(cat >&3)
-HTTP_STATUS=$(curl -w "%{http_code}" -o >(cat >&3) "http://$HOST/solr/$COLLECTION/update?commit=true$PROCESSOR" --data-binary @- -H 'Content-type:application/json')
+HTTP_STATUS=$(curl -w "%{http_code}" -o >(cat >&3) "http://$HOST/solr/$COLLECTION/update$PROCESSOR" --data-binary @- -H 'Content-type:application/json')
 
 if [[ ! $HTTP_STATUS == 2* ]];
 then

--- a/bin/load_scxa_analytics_index.sh
+++ b/bin/load_scxa_analytics_index.sh
@@ -19,7 +19,7 @@ I=O
 set +e
 for CHUNK_FILE in $CHUNK_FILES
 do
-  I=$(($I + 1)) 
+  I=$(($I + 1))
   echo "$CHUNK_FILE ${I}/$(wc -w <<< $CHUNK_FILES)"
   condSdrf2tsvForSCXAJSONFactorsIndex.sh $CHUNK_FILE | jsonFilterEmptyFields.sh | loadJSONIndexToSolr.sh
   STATUS=$?
@@ -28,14 +28,6 @@ done
 set -e
 rm $CHUNK_FILES
 
-HTTP_STATUS=$(curl -X POST -H 'Content-Type: application/json' \
-"http://$SOLR_HOST/solr/$SOLR_COLLECTION/update" --data-binary \
-'{ "commit": {} }')
-
-if [[ ! $HTTP_STATUS == 2* ]];
-then
-   echo "Commit operation failed with HTTP status $HTTP_STATUS"
-   exit 1
-fi
+solr-commit.sh
 
 exit $STATUS

--- a/bin/load_scxa_analytics_index.sh
+++ b/bin/load_scxa_analytics_index.sh
@@ -27,4 +27,11 @@ do
 done
 set -e
 rm $CHUNK_FILES
+
+curl -X POST -H 'Content-Type: application/json' \
+"http://$SOLR_HOST/solr/$SOLR_COLLECTION/update" --data-binary \
+'{
+  "commit": {}
+}'
+
 exit $STATUS

--- a/bin/load_scxa_analytics_index.sh
+++ b/bin/load_scxa_analytics_index.sh
@@ -28,10 +28,14 @@ done
 set -e
 rm $CHUNK_FILES
 
-curl -X POST -H 'Content-Type: application/json' \
+HTTP_STATUS=$(curl -X POST -H 'Content-Type: application/json' \
 "http://$SOLR_HOST/solr/$SOLR_COLLECTION/update" --data-binary \
-'{
-  "commit": {}
-}'
+'{ "commit": {} }')
+
+if [[ ! $HTTP_STATUS == 2* ]];
+then
+   echo "Commit operation failed with HTTP status $HTTP_STATUS"
+   exit 1
+fi
 
 exit $STATUS

--- a/bin/load_scxa_analytics_index.sh
+++ b/bin/load_scxa_analytics_index.sh
@@ -3,7 +3,7 @@ set -e
 
 [ -z ${CONDENSED_SDRF_TSV+x} ] && echo "CONDENSED_SDRF_TSV env var is needed." && exit 1
 
-export SCHEMA_VERSION=4
+export SCHEMA_VERSION=5
 export SOLR_COLLECTION=scxa-analytics-v$SCHEMA_VERSION
 export PROCESSOR=$SOLR_COLLECTION\_dedup
 export ONTOLOGY_PROCESSOR=$SOLR_COLLECTION\_ontology_expansion

--- a/bin/load_scxa_gene2experiment_index.sh
+++ b/bin/load_scxa_gene2experiment_index.sh
@@ -14,6 +14,11 @@ echo "Loading genes from $MATRIX_MARKT_ROWS_GENES_FILE into host $SOLR_HOST coll
 
 matrixMarktGenes2json.sh | loadJSONIndexToSolr.sh
 
-curl -X POST -H 'Content-Type: application/json' \
-  "http://${SOLR_HOST}/solr/${SOLR_COLLECTION}/update" --data-binary '{ "commit": {} }'
-
+HTTP_STATUS=$(curl -w "%{http_code}" -X POST -H 'Content-Type: application/json' \
+  "http://${SOLR_HOST}/solr/${SOLR_COLLECTION}/update" --data-binary '{ "commit": {} }')
+  
+if [[ ! $HTTP_STATUS == 2* ]];
+then
+   echo "Commit operation failed with HTTP status $HTTP_STATUS"
+   exit 1
+fi

--- a/bin/load_scxa_gene2experiment_index.sh
+++ b/bin/load_scxa_gene2experiment_index.sh
@@ -13,3 +13,7 @@ export PROCESSOR=$SOLR_COLLECTION\_dedup
 echo "Loading genes from $MATRIX_MARKT_ROWS_GENES_FILE into host $SOLR_HOST collection $SOLR_COLLECTION..."
 
 matrixMarktGenes2json.sh | loadJSONIndexToSolr.sh
+
+curl -X POST -H 'Content-Type: application/json' \
+  "http://${SOLR_HOST}/solr/${SOLR_COLLECTION}/update" --data-binary '{ "commit": {} }'
+

--- a/bin/load_scxa_gene2experiment_index.sh
+++ b/bin/load_scxa_gene2experiment_index.sh
@@ -14,11 +14,4 @@ echo "Loading genes from $MATRIX_MARKT_ROWS_GENES_FILE into host $SOLR_HOST coll
 
 matrixMarktGenes2json.sh | loadJSONIndexToSolr.sh
 
-HTTP_STATUS=$(curl -w "%{http_code}" -X POST -H 'Content-Type: application/json' \
-  "http://${SOLR_HOST}/solr/${SOLR_COLLECTION}/update" --data-binary '{ "commit": {} }')
-  
-if [[ ! $HTTP_STATUS == 2* ]];
-then
-   echo "Commit operation failed with HTTP status $HTTP_STATUS"
-   exit 1
-fi
+solr-commit.sh

--- a/bin/solr-commit.sh
+++ b/bin/solr-commit.sh
@@ -6,7 +6,7 @@ HTTP_STATUS=$(
 curl -X POST \
      -H 'Content-Type: application/json' \
      --data-binary '{ "commit": {} }' \
-     -s -o ${OUTPUT}  -w "%{http_code}" \
+     -s -o ${OUTPUT} -w "%{http_code}" \
      "http://${SOLR_HOST}/solr/${SOLR_COLLECTION}/update")
 
 if [[ ! $HTTP_STATUS == 2* ]];

--- a/bin/solr-commit.sh
+++ b/bin/solr-commit.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+OUTPUT=${SOLR_COMMIT_OUTPUT:-"/dev/null"}
+
+HTTP_STATUS=$(
+curl -X POST \
+     -H 'Content-Type: application/json' \
+     --data-binary '{ "commit": {} }' \
+     -s -o ${OUTPUT}  -w "%{http_code}" \
+     "http://${SOLR_HOST}/solr/${SOLR_COLLECTION}/update")
+
+if [[ ! $HTTP_STATUS == 2* ]];
+then
+  echo "Commit operation failed with HTTP status $HTTP_STATUS"
+  exit 1
+fi
+
+exit 0

--- a/run_tests_in_containers.sh
+++ b/run_tests_in_containers.sh
@@ -5,11 +5,11 @@ docker stop my_solr && docker rm my_solr
 
 
 docker network create mynet
-docker run --net mynet --name my_solr -v $(pwd)/lib/solr-ontology-update-processor-1.1.jar:/opt/solr/server/solr/lib/solr-ontology-update-processor-1.1.jar -d -p 8983:8983 -t solr:7.1-alpine -DzkRun -Denable.runtime.lib=true -m 2g
+docker run --net mynet --name my_solr -v $(pwd)/lib/solr-ontology-update-processor-1.2.jar:/opt/solr/server/solr/lib/solr-ontology-update-processor-1.2.jar -d -p 8983:8983 -t solr:7.1-alpine -DzkRun -Denable.runtime.lib=true -m 2g
 
 docker build -t test/index-scxa-module .
 sleep 20
 
-docker exec -it --user=solr my_solr bin/solr create_collection -c scxa-analytics-v3
+docker exec -it --user=solr my_solr bin/solr create_collection -c scxa-analytics-v5
 docker exec -it --user=solr my_solr bin/solr create_collection -c scxa-gene2experiment-v1
 docker run -i --net mynet -v $( pwd )/tests:/usr/local/tests -e SOLR_HOST=$SOLR_HOST --entrypoint=/usr/local/tests/run-tests.sh test/index-scxa-module

--- a/tests/analytics-check-created-fields.sh
+++ b/tests/analytics-check-created-fields.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-SCHEMA_VERSION=4
+SCHEMA_VERSION=5
 
 set -e
 

--- a/tests/analytics-check-experiment-available.sh
+++ b/tests/analytics-check-experiment-available.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-SCHEMA_VERSION=4
+SCHEMA_VERSION=5
 
 set -e
 

--- a/tests/analytics-check-index-content.sh
+++ b/tests/analytics-check-index-content.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -e
-SCHEMA_VERSION=4
+SCHEMA_VERSION=5
 
 # on developers environment export SOLR_HOST_PORT and export SOLR_COLLECTION before running
 HOST=${SOLR_HOST:-"localhost:8983"}

--- a/tests/analytics.bats
+++ b/tests/analytics.bats
@@ -1,5 +1,5 @@
 setup() {
-  export SOLR_COLLECTION=scxa-analytics-v4
+  export SOLR_COLLECTION=scxa-analytics-v5
 }
 
 @test "Check that curl is in the path" {


### PR DESCRIPTION
I updated the analytics collection to use the latest BioSolr version (btw, it’d be great if somebody could also review https://github.com/ebi-gene-expression-group/BioSolr/pull/4). With the latest version and the new parameters added, since we have no use for children or descendants, we can greatly reduce document size and the pressure on Solr from BioSolr’s update processor.

I also removed some default options and fields in the schema-creation script which ultimately had no effect on the resulting documents after ontology expansion.

What achieved a really big improvement was to disable soft and hard auto-commits and send an explicit commit request, however. I thought about this later and wasn’t the main focus of the branch! To get this up and running in production you’ll need to apply the config requests added at the end of `create-scxa-analytics-collection.sh`. This specific change can be cherry-picked onto whatever version of the collection you’re using.

P.S.: Sorry for the messy commit history; I think `git commit --amend` played tricks on me.