### PR TITLE
Make owl file a local URI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/jitesoft/alpine:3.8
+FROM quay.io/jitesoft/alpine:3.11
 
 RUN apk update && apk add bash curl jq bats
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.8
+FROM quay.io/jitesoft/alpine:3.8
 
 RUN apk update && apk add bash curl jq bats
 

--- a/bin/create-scxa-analytics-schema.sh
+++ b/bin/create-scxa-analytics-schema.sh
@@ -4,7 +4,7 @@ SCHEMA_VERSION=5
 # on developers environment export SOLR_HOST_PORT and export SOLR_COLLECTION before running
 HOST=${SOLR_HOST:-"localhost:8983"}
 CORE=${SOLR_COLLECTION:-"scxa-analytics-v$SCHEMA_VERSION"}
-SCXA_ONTOLOGY=${SOLR_ONTOLOGY:-"file:///srv/gxa/scatlas.owl"}
+SCXA_ONTOLOGY=${SCXA_ONTOLOGY:-"file:///srv/gxa/scatlas.owl"}
 
 #############################################################################################
 

--- a/bin/create-scxa-analytics-schema.sh
+++ b/bin/create-scxa-analytics-schema.sh
@@ -313,7 +313,7 @@ curl -X POST -H 'Content-type:application/json' --data-binary '{
     "runtimeLib": true,
     "class": "uk.co.flax.biosolr.solr.update.processor.OntologyUpdateProcessorFactory",
     "annotationField": "ontology_annotation",
-    "ontologyURI": "https://raw.githubusercontent.com/EBISPOT/scatlas_ontology/zooma_file_proc_release/scatlas.owl",
+    "ontologyURI": "file:///srv/gxa/scatlas.owl",
     "includeChildren": false,
     "includeDescendants": false
   }

--- a/bin/create-scxa-analytics-schema.sh
+++ b/bin/create-scxa-analytics-schema.sh
@@ -4,6 +4,7 @@ SCHEMA_VERSION=5
 # on developers environment export SOLR_HOST_PORT and export SOLR_COLLECTION before running
 HOST=${SOLR_HOST:-"localhost:8983"}
 CORE=${SOLR_COLLECTION:-"scxa-analytics-v$SCHEMA_VERSION"}
+SCXA_ONTOLOGY=${SOLR_ONTOLOGY:-"file:///srv/gxa/scatlas.owl"}
 
 #############################################################################################
 
@@ -313,7 +314,7 @@ curl -X POST -H 'Content-type:application/json' --data-binary '{
     "runtimeLib": true,
     "class": "uk.co.flax.biosolr.solr.update.processor.OntologyUpdateProcessorFactory",
     "annotationField": "ontology_annotation",
-    "ontologyURI": "file:///srv/gxa/scatlas.owl",
+    "ontologyURI": "'$SCXA_ONTOLOGY'",
     "includeChildren": false,
     "includeDescendants": false
   }

--- a/run_tests_in_containers.sh
+++ b/run_tests_in_containers.sh
@@ -5,7 +5,7 @@ docker stop my_solr && docker rm my_solr
 
 
 docker network create mynet
-docker run --net mynet --name my_solr -v $(pwd)/lib/solr-ontology-update-processor-1.2.jar:/opt/solr/server/solr/lib/solr-ontology-update-processor-1.2.jar -d -p 8983:8983 -t solr:7.1-alpine -DzkRun -Denable.runtime.lib=true -m 2g
+docker run --net mynet --name my_solr -v $( pwd )/tests:/usr/local/tests -v $(pwd)/lib/solr-ontology-update-processor-1.2.jar:/opt/solr/server/solr/lib/solr-ontology-update-processor-1.2.jar -d -p 8983:8983 -t solr:7.1-alpine -DzkRun -Denable.runtime.lib=true -m 2g
 
 docker build -t test/index-scxa-module .
 sleep 20

--- a/tests/analytics.bats
+++ b/tests/analytics.bats
@@ -65,10 +65,16 @@ setup() {
   [ "$status" -eq 0 ]
 }
 
+@test "Fetch SCXA OWL file" {
+    run curl https://raw.githubusercontent.com/EBISPOT/scatlas_ontology/zooma_file_proc_release/scatlas.owl > ${BATS_TEST_DIRNAME}/scatlas.owl 
+    [ -s "${BATS_TEST_DIRNAME}/scatlas.owl" ]
+}
+
 @test "[analytics] Load schema to collection on Solr" {
   if [ -z ${SOLR_HOST+x} ]; then
     skip "SOLR_HOST not defined, skipping loading of schema on Solr"
   fi
+  export SCXA_ONTOLOGY="${BATS_TEST_DIRNAME}/scatlas.owl"
   run create-scxa-analytics-schema.sh
   echo "output = ${output}"
   [ "$status" -eq 0 ]
@@ -172,6 +178,7 @@ setup() {
   if [ -z ${SOLR_HOST+x} ]; then
     skip "SOLR_HOST not defined, skipping loading of schema on Solr"
   fi
+  export SCXA_ONTOLOGY="${BATS_TEST_DIRNAME}/scatlas.owl"
   run create-scxa-analytics-schema.sh
   echo "output = ${output}"
   [ "$status" -eq 0 ]

--- a/tests/analytics.bats
+++ b/tests/analytics.bats
@@ -66,7 +66,7 @@ setup() {
 }
 
 @test "Fetch SCXA OWL file" {
-    run curl https://raw.githubusercontent.com/EBISPOT/scatlas_ontology/zooma_file_proc_release/scatlas.owl > ${BATS_TEST_DIRNAME}/scatlas.owl 
+    run wget -O ${BATS_TEST_DIRNAME}/scatlas.owl https://raw.githubusercontent.com/EBISPOT/scatlas_ontology/zooma_file_proc_release/scatlas.owl
     [ -s "${BATS_TEST_DIRNAME}/scatlas.owl" ]
 }
 

--- a/tests/analytics.bats
+++ b/tests/analytics.bats
@@ -74,7 +74,7 @@ setup() {
   if [ -z ${SOLR_HOST+x} ]; then
     skip "SOLR_HOST not defined, skipping loading of schema on Solr"
   fi
-  export SCXA_ONTOLOGY="${BATS_TEST_DIRNAME}/scatlas.owl"
+  export SCXA_ONTOLOGY="file://${BATS_TEST_DIRNAME}/scatlas.owl"
   run create-scxa-analytics-schema.sh
   echo "output = ${output}"
   [ "$status" -eq 0 ]
@@ -178,7 +178,7 @@ setup() {
   if [ -z ${SOLR_HOST+x} ]; then
     skip "SOLR_HOST not defined, skipping loading of schema on Solr"
   fi
-  export SCXA_ONTOLOGY="${BATS_TEST_DIRNAME}/scatlas.owl"
+  export SCXA_ONTOLOGY="file://${BATS_TEST_DIRNAME}/scatlas.owl"
   run create-scxa-analytics-schema.sh
   echo "output = ${output}"
   [ "$status" -eq 0 ]


### PR DESCRIPTION
This is a fix suggested by @alfonsomunozpomer which seemed required for the V5 analytics import. It solves an issue whereby uploads (using load_scxa_analytics_index.sh) would hang indefinitely, and errors like the following appear on the solr nodes:

```
2021-02-26 16:09:31.035 ERROR (qtp611437735-5514) [c:scxa-analytics-v5 s:shard4 r:core_node8 x:scxa-analytics-v5_shard4_replica_n4] u.c.f.b.o.c.o.OWLDataManager Error creating ontology: connect timed out
2021-02-26 16:09:31.035 ERROR (qtp611437735-5514) [c:scxa-analytics-v5 s:shard4 r:core_node8 x:scxa-analytics-v5_shard4_replica_n4] u.c.f.b.s.u.p.OntologyUpdateProcessorFactory Problem building ontology data for http://purl.obolibrary.org/obo/PATO_0000384: org.semanticweb.owlapi.io.OWLOntologyCreationIOException: connect timed out
2021-02-26 16:09:51.057 ERROR (qtp611437735-5514) [c:scxa-analytics-v5 s:shard4 r:core_node8 x:scxa-analytics-v5_shard4_replica_n4] u.c.f.b.o.c.o.OWLDataManager Error creating ontology: connect timed out
2021-02-26 16:09:51.057 ERROR (qtp611437735-5514) [c:scxa-analytics-v5 s:shard4 r:core_node8 x:scxa-analytics-v5_shard4_replica_n4] 
```