### PR TITLE
Feature/175873968 add suggester for ontology labels

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ env:
   - SOLR_HOST=my_solr:8983
 
 script:
-  - bash run_tests_in_containers.sh
+  - travis_wait bash run_tests_in_containers.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ env:
   - SOLR_HOST=my_solr:8983
 
 script:
-  - travis_wait bash run_tests_in_containers.sh
+  - travis_wait 60 bash run_tests_in_containers.sh

--- a/README.md
+++ b/README.md
@@ -54,6 +54,14 @@ For Single Cell Expression Atlas run:
 ```bash
 create-scxa-analytics-suggesters.sh
 ```
+## Suggesters Dictionary Implementation
+ We are using multiple dictionaries(dictionaryImpl) for a single SuggestComponent to fetch good number of suggestions.
+ ####Here is the Dictionary Implementations: 
+   - ontologyAnnotationSuggester
+   - ontologyAnnotationAncestorSuggester
+   - ontologyAnnotationParentSuggester
+   - ontologyAnnotationSynonymSuggester
+   - ontologyAnnotationChildSuggester
 
 ## Load data
 This module loads data from a condensed SDRF in an SCXA experiment to the scxa-analytics-v? collection in Solr. These routines expect the collection to be created already, and work as an update to the content of the collection.

--- a/README.md
+++ b/README.md
@@ -54,9 +54,13 @@ For Single Cell Expression Atlas run:
 ```bash
 create-scxa-analytics-suggesters.sh
 ```
+
 ## Suggesters Dictionary Implementation
- We are using multiple dictionaries(dictionaryImpl) for a single SuggestComponent to fetch good number of suggestions.
- #### Here is the Dictionary Implementations: 
+
+We are using multiple dictionaries (dictionaryImpl) for a single `SuggestComponent` to fetch various suggestions.
+
+#### Dictionary Implementations: 
+
    - ontologyAnnotationSuggester
    - ontologyAnnotationAncestorSuggester
    - ontologyAnnotationParentSuggester

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ You can override the default target Solr collection name by setting `SOLR_COLLEC
 
 ## Add suggesters
 
-For Single Cell Expression Atlas run:
+For the Single Cell Expression Atlas, run the script:
 
 ```bash
 create-scxa-analytics-suggesters.sh
@@ -67,6 +67,13 @@ We are using multiple dictionaries (dictionaryImpl) for a single `SuggestCompone
    - ontologyAnnotationParentSuggester
    - ontologyAnnotationSynonymSuggester
    - ontologyAnnotationChildSuggester
+
+## Build suggesters
+For the SCXA, to build suggesters with multiple dictionaries on the Solr, run this script:
+
+```bash
+build-scxa-analytics-suggestions.sh
+```
 
 ## Load data
 This module loads data from a condensed SDRF in an SCXA experiment to the scxa-analytics-v? collection in Solr. These routines expect the collection to be created already, and work as an update to the content of the collection.

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ create-scxa-analytics-suggesters.sh
 ```
 ## Suggesters Dictionary Implementation
  We are using multiple dictionaries(dictionaryImpl) for a single SuggestComponent to fetch good number of suggestions.
- ####Here is the Dictionary Implementations: 
+ #### Here is the Dictionary Implementations: 
    - ontologyAnnotationSuggester
    - ontologyAnnotationAncestorSuggester
    - ontologyAnnotationParentSuggester

--- a/README.md
+++ b/README.md
@@ -48,6 +48,13 @@ create-scxa-analytics-schema.sh
 
 You can override the default target Solr collection name by setting `SOLR_COLLECTION`, but remember to include the additional `v<schema-version-number>` at the end, or the loader might refuse to load this.
 
+## Add suggesters
+
+For Single Cell Expression Atlas run:
+```bash
+create-scxa-analytics-suggesters.sh
+```
+
 ## Load data
 This module loads data from a condensed SDRF in an SCXA experiment to the scxa-analytics-v? collection in Solr. These routines expect the collection to be created already, and work as an update to the content of the collection.
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ You can override the default target Solr collection name by setting `SOLR_COLLEC
 ## Add suggesters
 
 For Single Cell Expression Atlas run:
+
 ```bash
 create-scxa-analytics-suggesters.sh
 ```

--- a/bin/build-scxa-analytics-suggestions.sh
+++ b/bin/build-scxa-analytics-suggestions.sh
@@ -39,7 +39,6 @@ fi
 
 # Verify zero status and valid response in all suggesters
 
-success=''
 fails=$suggesters
 testQuery=skin
 maxTries=5
@@ -60,10 +59,11 @@ while [ -n "$fails" ] && [ "$counter" -lt "$maxTries" ]; do
         statusCode=$(echo -e "$response" | jq '.responseHeader.status')
         numFound=$(echo -e "$response" | jq ".suggest.${suggester}.${testQuery}.numFound")
        
-
         if [ "$statusCode" -eq '0' ] && [ -n "$numFound" ] && [ "$numFound" -gt '0' ]; then
             echo "$suggester built and producing valid response"
-            success="$success $suggester"
+
+        elif [ "$statusCode" -eq '0' && "$suggester" == 'ontologyAnnotationChildSuggester' ]; then
+            echo "(no test string currently set that works with $suggester)"
         else
             echo "$suggester produced either invalid status code ($statusCode) or number of results ($numFound)" 1>&2
             newFails="$newFails $suggester"  

--- a/bin/build-scxa-analytics-suggestions.sh
+++ b/bin/build-scxa-analytics-suggestions.sh
@@ -25,13 +25,14 @@ if [ "$BUILD" = true ] ; then
         # For some reason the error trace that can come back invalidates the
         # json so we need some 'tr' and 'sed' magic
         
-        response=$(curl "$REQUEST_URI&suggest.build=true&suggest.dictionary=$suggester" | tr -d '\n' | sed 's/\t/ /g' 2> /dev/null)
+        response=$(curl "$REQUEST_URI&suggest.build=true&suggest.dictionary=$suggester" 2> /dev/null)
+        response=$(echo -e "$response" | tr -d '\n' | sed 's/\t/ /g')
         statusCode=$(echo -e "$response" | jq '.responseHeader.status')
         
         if [ "$statusCode" -eq '0' ]; then
             echo "Successfully built suggester: $suggester"
         else
-            echo -e "Failed to build suggester $suggester, resoponse was: \n\n$response\n" 1>&2
+            echo -e "Failed to build suggester $suggester, response was: \n\n$response\n" 1>&2
         fi
     done
 fi
@@ -53,7 +54,9 @@ while [ -n "$fails" ] && [ "$counter" -lt "$maxTries" ]; do
     # that still-building suggesters provide a return code of 500.
 
     for suggester in $suggesters; do
-        response=$(curl -X GET "$REQUEST_URI&suggest.dictionary=$suggester&suggest.q=$testQuery" | tr -d '\n' | sed 's/\t/ /g' 2> /dev/null)
+        response=$(curl -X GET "$REQUEST_URI&suggest.dictionary=$suggester&suggest.q=$testQuery" 2> /dev/null)
+        response=$(echo -e "$response" | tr -d '\n' | sed 's/\t/ /g')
+
         statusCode=$(echo -e "$response" | jq '.responseHeader.status')
         numFound=$(echo -e "$response" | jq ".suggest.${suggester}.${testQuery}.numFound")
        

--- a/bin/build-scxa-analytics-suggestions.sh
+++ b/bin/build-scxa-analytics-suggestions.sh
@@ -1,9 +1,14 @@
-#!/bin/bash
+#!/usr/bin/env bash
+SCHEMA_VERSION=5
 
 #This below long curl request build suggestions on the solr server for the mentioned dictionaries as part of http request
 #Once build request completes, user can search for the suggestions
 # To search for the suggestions, here is the curl request:
 # curl -X GET 'http://localhost:8983/solr/scxa-analytics-v5/suggest?suggest=true&suggest.dictionary=ontologyAnnotationSuggester&suggest.dictionary=ontologyAnnotationAncestorSuggester&suggest.dictionary=ontologyAnnotationParentSuggester&suggest.dictionary=ontologyAnnotationSynonymSuggester&suggest.dictionary=ontologyAnnotationChildSuggester&suggest.q=skin'
 
-curl -X GET 'http://localhost:8983/solr/scxa-analytics-v5/suggest?suggest=true&suggest.build=true&suggest.dictionary=ontologyAnnotationSuggester&suggest.dictionary=ontologyAnnotationAncestorSuggester&suggest.dictionary=ontologyAnnotationParentSuggester&suggest.dictionary=ontologyAnnotationSynonymSuggester&suggest.dictionary=ontologyAnnotationChildSuggester'
+# on developers environment export SOLR_HOST and export SOLR_COLLECTION before running
+HOST=${SOLR_HOST:-"localhost:8983"}
+COLLECTION=${SOLR_COLLECTION:-"scxa-analytics-v${SCHEMA_VERSION}"}
+
+curl "http://$HOST/solr/$COLLECTION/suggest?suggest=true&suggest.build=true&suggest.dictionary=ontologyAnnotationSuggester&suggest.dictionary=ontologyAnnotationAncestorSuggester&suggest.dictionary=ontologyAnnotationParentSuggester&suggest.dictionary=ontologyAnnotationSynonymSuggester&suggest.dictionary=ontologyAnnotationChildSuggester"
 

--- a/bin/build-scxa-analytics-suggestions.sh
+++ b/bin/build-scxa-analytics-suggestions.sh
@@ -25,7 +25,7 @@ if [ "$BUILD" = true ] ; then
         # For some reason the error trace that can come back invalidates the
         # json so we need some 'tr' and 'sed' magic
         
-        response=$(curl "$REQUEST_URI&suggest.build=true&suggest.dictionary=$suggester" 2> /dev/null)
+        response=$(curl "$REQUEST_URI&suggest.build=true&suggest.dictionary=$suggester")
         response=$(echo -e "$response" | tr -d '\n' | sed 's/\t/ /g')
         statusCode=$(echo -e "$response" | jq '.responseHeader.status')
         

--- a/bin/build-scxa-analytics-suggestions.sh
+++ b/bin/build-scxa-analytics-suggestions.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+#This below long curl request build suggestions on the solr server for the mentioned dictionaries as part of http request
+#Once build request completes, user can search for the suggestions
+# To search for the suggestions, here is the curl request:
+# curl -X GET 'http://localhost:8983/solr/scxa-analytics-v5/suggest?suggest=true&suggest.dictionary=ontologyAnnotationSuggester&suggest.dictionary=ontologyAnnotationAncestorSuggester&suggest.dictionary=ontologyAnnotationParentSuggester&suggest.dictionary=ontologyAnnotationSynonymSuggester&suggest.dictionary=ontologyAnnotationChildSuggester&suggest.q=skin'
+
+curl -X GET 'http://localhost:8983/solr/scxa-analytics-v5/suggest?suggest=true&suggest.build=true&suggest.dictionary=ontologyAnnotationSuggester&suggest.dictionary=ontologyAnnotationAncestorSuggester&suggest.dictionary=ontologyAnnotationParentSuggester&suggest.dictionary=ontologyAnnotationSynonymSuggester&suggest.dictionary=ontologyAnnotationChildSuggester'
+

--- a/bin/build-scxa-analytics-suggestions.sh
+++ b/bin/build-scxa-analytics-suggestions.sh
@@ -44,7 +44,7 @@ testQuery=skin
 maxTries=5
 counter=0
 
-while [ -n "$fails" ]; do
+while [ -n "$fails" ] && [ "$counter" -lt "$maxTries" ]; do
 
     newFails=''
 
@@ -69,8 +69,9 @@ while [ -n "$fails" ]; do
 
     # If we have fails, give it 5 mins and try again (up to $maxTries tries) 
 
+    counter=$((counter+1))
     if [ -n "$newFails" ]; then
-        if [ "$counter" -lt "$maxTries"  ]; then
+        if [ "$counter" -lt "$maxTries" ]; then
             echo "Still have failing suggesters, sleeping for 5 mins before a retry" 1>&2
             sleep 5m
         else
@@ -80,7 +81,6 @@ while [ -n "$fails" ]; do
 
     # Just remove any leading spaces from fails
     fails=$(echo -e "$newFails" | sed 's/^ //')
-    counter=$((counter+1))
 
 done
 

--- a/bin/build-scxa-analytics-suggestions.sh
+++ b/bin/build-scxa-analytics-suggestions.sh
@@ -75,7 +75,7 @@ while [ -n "$fails" ] && [ "$counter" -lt "$maxTries" ]; do
     counter=$((counter+1))
     if [ -n "$newFails" ]; then
         if [ "$counter" -lt "$maxTries" ]; then
-            echo "Still have failing suggesters, sleeping for 5 mins before a retry" 1>&2
+            echo "This was try $counter. Still have failing suggesters, sleeping for 5 mins before a retry (max tries $maxTries)" 1>&2
             sleep 5m
         else
             echo "Still failing but retries exceeded, no more retries" 1>&2

--- a/bin/build-scxa-analytics-suggestions.sh
+++ b/bin/build-scxa-analytics-suggestions.sh
@@ -69,7 +69,7 @@ while [ -n "$fails" ] && [ "$counter" -lt "$maxTries" ]; do
                 fi
             fi
         else
-            echo "$suggester build failed, status code $statusCode"
+            echo "Error: $suggester build failed, status code $statusCode" 1>&2
             newFails="$newFails $suggester"
         fi
     done

--- a/bin/build-scxa-analytics-suggestions.sh
+++ b/bin/build-scxa-analytics-suggestions.sh
@@ -62,7 +62,7 @@ while [ -n "$fails" ] && [ "$counter" -lt "$maxTries" ]; do
         if [ "$statusCode" -eq '0' ] && [ -n "$numFound" ] && [ "$numFound" -gt '0' ]; then
             echo "$suggester built and producing valid response"
 
-        elif [ "$statusCode" -eq '0' && "$suggester" == 'ontologyAnnotationChildSuggester' ]; then
+        elif [ "$statusCode" -eq '0' ] && [ "$suggester" == 'ontologyAnnotationChildSuggester' ]; then
             echo "(no test string currently set that works with $suggester)"
         else
             echo "$suggester produced either invalid status code ($statusCode) or number of results ($numFound)" 1>&2

--- a/bin/create-scxa-analytics-suggesters.sh
+++ b/bin/create-scxa-analytics-suggesters.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+. ${DIR}/schema-version.env
+
+# On developers environment export SOLR_HOST and export SOLR_COLLECTION before running
+HOST=${SOLR_HOST:-"localhost:8983"}
+COLLECTION=${SOLR_COLLECTION:-"scxa-analytics-v${SCHEMA_VERSION}"}
+
+#############################################################################################
+
+printf "\n\nDelete search component for suggesters"
+CURL -X POST -H 'Content-Type: application/json' -d '{
+  "delete-searchcomponent" : "suggest"
+}' http://${HOST}/solr/${COLLECTION}/config
+
+
+printf "\n\nCreate search component for suggesters"
+CURL -X POST -H 'Content-Type: application/json' -d '{
+  "add-searchcomponent": {
+       "name": "suggest",
+       "class": "solr.SuggestComponent",
+       "suggester" : [
+           {
+            "name": "ontologyAnnotationSuggester",
+            "indexPath": "ontologyAnnotationSuggester",
+            "lookupImpl": "AnalyzingInfixLookupFactory",
+            "dictionaryImpl": "DocumentDictionaryFactory",
+            "field": "ontology_annotation_label_t",
+            "payloadField": "ontology_annotation_label_t",
+            "suggestAnalyzerFieldType": "text_en",
+            "queryAnalyzerFieldType": "text_en",
+            "buildOnStartup": "false"
+           },
+           {
+            "name": "ontologyAnnotationAncestorSuggester",
+            "indexPath": "ontologyAnnotationAncestorSuggester",
+            "lookupImpl": "AnalyzingInfixLookupFactory",
+            "dictionaryImpl": "DocumentDictionaryFactory",
+            "field": "ontology_annotation_ancestors_labels_t",
+            "payloadField": "ontology_annotation_ancestors_labels_t",
+            "suggestAnalyzerFieldType": "text_en",
+            "queryAnalyzerFieldType": "text_en",
+            "buildOnStartup": "false"
+            }
+            ,
+            {
+                "name": "ontologyAnnotationParentSuggester",
+                "indexPath": "ontologyAnnotationParentSuggester",
+                "lookupImpl": "AnalyzingInfixLookupFactory",
+                "dictionaryImpl": "DocumentDictionaryFactory",
+                "field": "ontology_annotation_parent_labels_t",
+                "payloadField": "ontology_annotation_parent_labels_t",
+                "suggestAnalyzerFieldType": "text_en",
+                "queryAnalyzerFieldType": "text_en",
+                "buildOnStartup": "false"
+            },
+            {
+                "name": "ontologyAnnotationSynonymSuggester",
+                "indexPath": "ontologyAnnotationSynonymSuggester",
+                "lookupImpl": "AnalyzingInfixLookupFactory",
+                "dictionaryImpl": "DocumentDictionaryFactory",
+                "field": "ontology_annotation_synonyms_t",
+                "payloadField": "ontology_annotation_synonyms_t",
+                "suggestAnalyzerFieldType": "text_en",
+                "queryAnalyzerFieldType": "text_en",
+                "buildOnStartup": "false"
+            },
+            {
+                "name": "ontologyAnnotationChildSuggester",
+                "indexPath": "ontologyAnnotationChildSuggester",
+                "lookupImpl": "AnalyzingInfixLookupFactory",
+                "dictionaryImpl": "DocumentDictionaryFactory",
+                "field": "ontology_annotation_child_labels_t",
+                "payloadField": "ontology_annotation_child_labels_t",
+                "suggestAnalyzerFieldType": "text_en",
+                "queryAnalyzerFieldType": "text_en",
+                "buildOnStartup": "false"
+            }
+       ]
+    }
+}' http://${HOST}/solr/${COLLECTION}/config
+
+#############################################################################################
+
+printf "\n\nDelete request handler /suggest"
+CURL -X POST -H 'Content-Type: application/json' -d '{
+    "delete-requesthandler" :  "/suggest"
+}' http://${HOST}/solr/${COLLECTION}/config
+
+
+printf "\n\nCreate request handler /suggest"
+CURL -X POST -H 'Content-Type: application/json' -d '{
+    "add-requesthandler" : {
+        "name":"/suggest",
+        "class":"solr.SearchHandler",
+        "startup":"lazy",
+        "defaults":{
+        "suggest":"true",
+        "suggest.count":100},
+        "components":["suggest"]
+    }
+}' http://${HOST}/solr/${COLLECTION}/config

--- a/bin/create-scxa-analytics-suggesters.sh
+++ b/bin/create-scxa-analytics-suggesters.sh
@@ -10,13 +10,13 @@ COLLECTION=${SOLR_COLLECTION:-"scxa-analytics-v${SCHEMA_VERSION}"}
 #############################################################################################
 
 printf "\n\nDelete search component for suggesters"
-CURL -X POST -H 'Content-Type: application/json' -d '{
+curl -X POST -H 'Content-Type: application/json' -d '{
   "delete-searchcomponent" : "suggest"
 }' http://${HOST}/solr/${COLLECTION}/config
 
 
 printf "\n\nCreate search component for suggesters"
-CURL -X POST -H 'Content-Type: application/json' -d '{
+curl -X POST -H 'Content-Type: application/json' -d '{
   "add-searchcomponent": {
        "name": "suggest",
        "class": "solr.SuggestComponent",
@@ -84,13 +84,13 @@ CURL -X POST -H 'Content-Type: application/json' -d '{
 #############################################################################################
 
 printf "\n\nDelete request handler /suggest"
-CURL -X POST -H 'Content-Type: application/json' -d '{
+curl -X POST -H 'Content-Type: application/json' -d '{
     "delete-requesthandler" :  "/suggest"
 }' http://${HOST}/solr/${COLLECTION}/config
 
 
 printf "\n\nCreate request handler /suggest"
-CURL -X POST -H 'Content-Type: application/json' -d '{
+curl -X POST -H 'Content-Type: application/json' -d '{
     "add-requesthandler" : {
         "name":"/suggest",
         "class":"solr.SearchHandler",

--- a/bin/create-scxa-analytics-suggesters.sh
+++ b/bin/create-scxa-analytics-suggesters.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+
+set -e
+
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 . ${DIR}/schema-version.env

--- a/bin/create-scxa-analytics-suggesters.sh
+++ b/bin/create-scxa-analytics-suggesters.sh
@@ -4,7 +4,6 @@ set -e
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
-. ${DIR}/schema-version.env
 
 # On developers environment export SOLR_HOST and export SOLR_COLLECTION before running
 HOST=${SOLR_HOST:-"localhost:8983"}

--- a/tests/analytics.bats
+++ b/tests/analytics.bats
@@ -235,3 +235,13 @@ setup() {
   echo "output = ${output}"
   [ "$status" -eq 0 ]
 }
+
+@test "[analytics] Re-Load suggesters to collection on Solr" {
+  if [ -z ${SOLR_HOST+x} ]; then
+    skip "SOLR_HOST not defined, skipping loading of suggesters on Solr"
+  fi
+  export SCHEMA_VERSION=5
+  run create-scxa-analytics-suggesters.sh
+  echo "output = ${output}"
+  [ "$status" -eq 0 ]
+}

--- a/tests/analytics.bats
+++ b/tests/analytics.bats
@@ -245,3 +245,13 @@ setup() {
   echo "output = ${output}"
   [ "$status" -eq 0 ]
 }
+
+@test "[analytics] build suggesters on Solr" {
+  if [ -z ${SOLR_HOST+x} ]; then
+    skip "SOLR_HOST not defined, skip building of suggesters on Solr"
+  fi
+  export SCHEMA_VERSION=5
+  run build-scxa-analytics-suggestions.sh
+  echo "output = ${output}"
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
 - Bash script to create suggester components and delete any existing suggester components before creating new suggesters in the `scxa-analytics-v5` 

- Testing script to test above fucntionality

**Edit, Jon, 19th May '21:** Building all dictionaries at once was timing out. Adding an edit to build them one-by-one helps, but some still don't complete before timing out, though @alfonsomunozpomer says they complete in the background. They seem to show 500s when building, and 0 when complete, so I've also added some post-hoc testing along with functional tests to make sure terms are actually retrieved from the built suggesters.
